### PR TITLE
Update Duct keys to work within a Duct 0.11 app

### DIFF
--- a/src/duct/module/ataraxy.clj
+++ b/src/duct/module/ataraxy.clj
@@ -28,7 +28,7 @@
           middleware (infer-middleware routes project-ns)]
       (duct/merge-configs
        config
-       {:duct.core/handler
+       {:duct.handler/root
         {:router (ig/ref :duct.router/ataraxy)}
         :duct.router/ataraxy
         {:routes     (with-meta routes {:demote true})

--- a/test/duct/module/ataraxy_test.clj
+++ b/test/duct/module/ataraxy_test.clj
@@ -37,7 +37,7 @@
 (deftest module-test
   (testing "basic config"
     (is (= (merge (:duct.profile/base basic-config)
-                  {:duct.core/handler
+                  {:duct.handler/root
                    {:router (ig/ref :duct.router/ataraxy)}
                    :duct.router/ataraxy
                    {:routes
@@ -52,7 +52,7 @@
 
   (testing "updated handlers"
     (is (= (merge (:duct.profile/base updated-handlers-config)
-                  {:duct.core/handler
+                  {:duct.handler/root
                    {:router (ig/ref :duct.router/ataraxy)}
                    :duct.router/ataraxy
                    {:routes


### PR DESCRIPTION
Update `module.ataraxy` to work with **Duct 0.11**.

This simply means replacing `:duct.core/handler` with `:duct.handler/root`.